### PR TITLE
Fix responsive layout

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -22,7 +22,7 @@ export default function Home() {
         
         {/* Example of GradientDisplay as per prompt */}
         <section className="py-16 md:py-24 bg-neutral-800">
-          <div className="container mx-auto px-6">
+          <div className="w-full mx-auto px-6 2xl:max-w-none">
             <h2 className="font-display text-3xl font-bold text-center text-neutral-100 mb-12">
               Demonstração de Gradiente Dinâmico
             </h2>

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -5,7 +5,7 @@ export default function PrivacyPage() {
   return (
     <div className="flex flex-col min-h-screen bg-neutral-900">
       <Header />
-      <main className="flex-grow container mx-auto px-6 py-12">
+      <main className="flex-grow w-full mx-auto px-6 py-12 2xl:max-w-none">
         <h1 className="font-display text-4xl font-bold text-neutral-100 mb-8">Política de Privacidade</h1>
         <div className="prose prose-invert max-w-none text-neutral-300 space-y-4">
           <p>Sua privacidade é importante para nós. É política do FiscalFlux respeitar sua privacidade em relação a qualquer informação sua que possamos coletar no site FiscalFlux, e outros sites que possuímos e operamos.</p>

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -5,7 +5,7 @@ export default function TermsPage() {
   return (
     <div className="flex flex-col min-h-screen bg-neutral-900">
       <Header />
-      <main className="flex-grow container mx-auto px-6 py-12">
+      <main className="flex-grow w-full mx-auto px-6 py-12 2xl:max-w-none">
         <h1 className="font-display text-4xl font-bold text-neutral-100 mb-8">Termos de Uso</h1>
         <div className="prose prose-invert max-w-none text-neutral-300 space-y-4">
           <p>Bem-vindo ao FiscalFlux!</p>

--- a/src/components/dynamic-data-viz-wrapper.tsx
+++ b/src/components/dynamic-data-viz-wrapper.tsx
@@ -8,7 +8,10 @@ const DataVisualizationSectionComponent = dynamic(
   () => import('@/components/sections/data-visualization-section'),
   {
     loading: () => (
-      <div className="py-16 md:py-24 bg-neutral-800 flex justify-center items-center min-h-[400px]">
+      <div
+        className="py-16 md:py-24 bg-neutral-800 flex justify-center items-center"
+        style={{ minHeight: "clamp(300px, 40vh, 600px)" }}
+      >
         <SaturnLoader message="Carregando visualizações..." size={48} />
       </div>
     ),

--- a/src/components/layout/footer.tsx
+++ b/src/components/layout/footer.tsx
@@ -6,7 +6,7 @@ export default function Footer() {
 
   return (
     <footer className="border-t border-neutral-700 bg-neutral-900 text-neutral-400">
-      <div className="container mx-auto flex flex-col items-center justify-between px-6 py-8 sm:flex-row">
+      <div className="w-full mx-auto px-6 py-8 2xl:max-w-none flex flex-col items-center justify-between sm:flex-row">
         <div className="flex items-center space-x-2">
           <SaturnIcon className="h-6 w-6 text-neutral-500" />
           <p className="text-sm">

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -7,7 +7,7 @@ import { ThemeToggle } from '@/components/theme-toggle';
 export default function Header() {
   return (
     <header className="sticky top-0 z-50 w-full border-b border-neutral-700 bg-neutral-900/80 backdrop-blur-sm">
-      <div className="container flex h-16 items-center justify-between px-4 sm:px-6 lg:px-8">
+      <div className="w-full mx-auto px-4 sm:px-6 lg:px-8 2xl:max-w-none flex h-16 items-center justify-between">
         {/* Left Group: Logo and Desktop Nav Links */}
         <div className="flex items-center">
           <Link href="/" className="mr-6 flex items-center space-x-2">

--- a/src/components/sections/ai-insights-section.tsx
+++ b/src/components/sections/ai-insights-section.tsx
@@ -57,7 +57,7 @@ export default function AiInsightsSection() {
 
   return (
     <section id="ai-insights" className="py-16 md:py-24 bg-neutral-900">
-      <div className="container mx-auto px-6">
+      <div className="w-full mx-auto px-6 2xl:max-w-none">
         <h2 className="font-display text-3xl font-bold text-center text-neutral-100 mb-4">
           Insights com Inteligência Artificial <Wand2 className="inline-block ml-2 h-8 w-8 text-primary" />
         </h2>
@@ -80,7 +80,7 @@ export default function AiInsightsSection() {
                   value={fiscalData}
                   onChange={(e) => setFiscalData(e.target.value)}
                   placeholder="Insira seus dados fiscais aqui..."
-                  className="custom-input mt-1 min-h-[100px]"
+                  className="custom-input mt-1 min-h-24"
                   rows={4}
                 />
               </div>

--- a/src/components/sections/data-visualization-section.tsx
+++ b/src/components/sections/data-visualization-section.tsx
@@ -28,7 +28,7 @@ const chartConfig = {
 export default function DataVisualizationSection() {
   return (
     <section id="data-visualization" className="py-16 md:py-24 bg-neutral-800">
-      <div className="container mx-auto px-6">
+      <div className="w-full mx-auto px-6 2xl:max-w-none">
         <h2 className="font-display text-3xl font-bold text-center text-neutral-100 mb-4">
           Visualização de Dados
         </h2>
@@ -41,7 +41,11 @@ export default function DataVisualizationSection() {
             <CardDescription className="text-neutral-400">Comparativo dos últimos 6 meses</CardDescription>
           </CardHeader>
           <CardContent>
-            <ChartContainer config={chartConfig} className="w-full aspect-video h-[500px] md:h-[600px]"> {/* Ajustei altura para desktop */}
+            <ChartContainer
+              config={chartConfig}
+              className="w-full aspect-video"
+              style={{ height: "clamp(400px, 50vh, 800px)" }}
+            >
               <BarChart data={chartData} margin={{ top: 20, right: 20, left: -20, bottom: 5 }}>
                 <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" />
                 <XAxis dataKey="month" tickLine={false} axisLine={false} stroke="hsl(var(--muted-foreground))" />

--- a/src/components/sections/hero-section.tsx
+++ b/src/components/sections/hero-section.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 export default function HeroSection() {
   return (
     <section id="hero" className="py-20 md:py-32 bg-gradient-to-br from-neutral-900 via-neutral-800 to-neutral-900">
-      <div className="container mx-auto px-6 text-center">
+      <div className="w-full mx-auto px-6 2xl:max-w-none text-center">
         <h1 className="font-display text-4xl font-bold text-neutral-100 sm:text-5xl md:text-6xl lg:text-7xl">
           Bem-vindo ao <span className="text-primary">FiscalFlux</span>
         </h1>

--- a/src/components/sections/tools-metrics-section.tsx
+++ b/src/components/sections/tools-metrics-section.tsx
@@ -43,7 +43,7 @@ const tools = [
 export default function ToolsMetricsSection() {
   return (
     <section id="tools" className="py-16 md:py-24 bg-neutral-900">
-      <div className="container mx-auto px-6">
+      <div className="w-full mx-auto px-6 2xl:max-w-none">
         <h2 className="font-display text-3xl font-bold text-center text-neutral-100 mb-4">
           Ferramentas e Métricas
         </h2>

--- a/src/components/ui/alert.tsx
+++ b/src/components/ui/alert.tsx
@@ -4,7 +4,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const alertVariants = cva(
-  "relative w-full rounded-lg border p-4 [&>svg~*]:pl-7 [&>svg+div]:translate-y-[-3px] [&>svg]:absolute [&>svg]:left-4 [&>svg]:top-4 [&>svg]:text-foreground",
+  "flex items-start w-full rounded-lg border p-4 [&>svg]:mr-3 [&>svg]:flex-shrink-0",
   {
     variants: {
       variant: {

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -20,10 +20,10 @@ const buttonVariants = cva(
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {
-        default: "h-10 px-4 py-2",
-        sm: "h-9 rounded-md px-3",
-        lg: "h-11 rounded-md px-8",
-        icon: "h-10 w-10",
+        default: "px-4 py-2",
+        sm: "rounded-md px-3 py-1.5",
+        lg: "rounded-md px-8 py-3",
+        icon: "p-2",
       },
     },
     defaultVariants: {

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -8,7 +8,7 @@ const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
       <input
         type={type}
         className={cn(
-          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+          "flex w-full rounded-md border border-input bg-background px-3 py-2 text-base leading-normal ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
           className
         )}
         ref={ref}

--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -12,9 +12,10 @@ const Progress = React.forwardRef<
   <ProgressPrimitive.Root
     ref={ref}
     className={cn(
-      "relative h-4 w-full overflow-hidden rounded-full bg-secondary",
+      "relative w-full overflow-hidden rounded-full bg-secondary",
       className
     )}
+    style={{ height: "0.5rem" }}
     {...props}
   >
     <ProgressPrimitive.Indicator

--- a/src/components/ui/saturn-loader.tsx
+++ b/src/components/ui/saturn-loader.tsx
@@ -8,11 +8,13 @@ interface SaturnLoaderProps {
 export default function SaturnLoader({ size = 64, message }: SaturnLoaderProps) {
   return (
     <div className="flex flex-col items-center justify-center space-y-4 p-4">
-      <SaturnIcon 
-        className="text-primary animate-spin" 
-        style={{ animationDuration: '2s' }}
-        width={size}
-        height={size}
+      <SaturnIcon
+        className="text-primary animate-spin"
+        style={{
+          animationDuration: '2s',
+          width: `clamp(30px, ${size}px, 80px)`,
+          height: `clamp(30px, ${size}px, 80px)`
+        }}
       />
       {message && <p className="text-neutral-300 text-sm">{message}</p>}
     </div>

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -22,9 +22,6 @@ import {
 
 const SIDEBAR_COOKIE_NAME = "sidebar_state"
 const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7
-const SIDEBAR_WIDTH = "16rem"
-const SIDEBAR_WIDTH_MOBILE = "18rem"
-const SIDEBAR_WIDTH_ICON = "3rem"
 const SIDEBAR_KEYBOARD_SHORTCUT = "b"
 
 type SidebarContext = {
@@ -134,15 +131,13 @@ const SidebarProvider = React.forwardRef<
       <SidebarContext.Provider value={contextValue}>
         <TooltipProvider delayDuration={0}>
           <div
-            style={
-              {
-                "--sidebar-width": SIDEBAR_WIDTH,
-                "--sidebar-width-icon": SIDEBAR_WIDTH_ICON,
-                ...style,
-              } as React.CSSProperties
-            }
+            style={{
+              "--sidebar-width": "minmax(200px,20%)",
+              "--sidebar-width-icon": "3rem",
+              ...style,
+            } as React.CSSProperties}
             className={cn(
-              "group/sidebar-wrapper flex flex-col md:flex-row min-h-svh w-full has-[[data-variant=inset]]:bg-sidebar",
+              "group/sidebar-wrapper grid h-screen w-full grid-cols-[minmax(200px,20%)_1fr] has-[[data-variant=inset]]:bg-sidebar",
               className
             )}
             ref={ref}
@@ -200,11 +195,9 @@ const Sidebar = React.forwardRef<
             data-sidebar="sidebar"
             data-mobile="true"
             className="w-[--sidebar-width] bg-sidebar p-0 text-sidebar-foreground [&>button]:hidden"
-            style={
-              {
-                "--sidebar-width": SIDEBAR_WIDTH_MOBILE,
-              } as React.CSSProperties
-            }
+            style={{
+              "--sidebar-width": "clamp(200px,75vw,22rem)",
+            } as React.CSSProperties}
             side={side}
           >
             <div className="flex h-full w-full flex-col">{children}</div>
@@ -229,7 +222,7 @@ const Sidebar = React.forwardRef<
             "group-data-[collapsible=offcanvas]:w-0",
             "group-data-[side=right]:rotate-180",
             variant === "floating" || variant === "inset"
-              ? "group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)_+_theme(spacing.4))]"
+              ? "group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+theme(spacing.4))]"
               : "group-data-[collapsible=icon]:w-[--sidebar-width-icon]"
           )}
         />
@@ -241,7 +234,7 @@ const Sidebar = React.forwardRef<
               : "right-0 group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)]",
             // Adjust the padding for floating and inset variants.
             variant === "floating" || variant === "inset"
-              ? "p-2 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)_+_theme(spacing.4)_+2px)]"
+              ? "p-2 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+theme(spacing.4))]"
               : "group-data-[collapsible=icon]:w-[--sidebar-width-icon] group-data-[side=left]:border-r group-data-[side=right]:border-l",
             className
           )}

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -7,7 +7,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, React.ComponentProps<'tex
     return (
       <textarea
         className={cn(
-          'flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+          'flex min-h-20 w-full rounded-md border border-input bg-background px-3 py-2 text-base leading-relaxed ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
           className
         )}
         ref={ref}

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -16,9 +16,10 @@ const ToastViewport = React.forwardRef<
   <ToastPrimitives.Viewport
     ref={ref}
     className={cn(
-      "fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]",
+      "fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col",
       className
     )}
+    style={{ maxWidth: "clamp(320px, 30vw, 600px)" }}
     {...props}
   />
 ))

--- a/src/components/ui/tool-card.tsx
+++ b/src/components/ui/tool-card.tsx
@@ -14,13 +14,13 @@ interface ToolCardProps {
 export default function ToolCard({ title, description, icon: IconComponent, isLoading, className, iconColorClassName = "text-primary" }: ToolCardProps) {
   if (isLoading) {
     return (
-      <Card className="bg-neutral-800 shadow-md hover:shadow-lg transition duration-200 transform hover:-translate-y-1 w-full h-full min-h-[180px]">
+      <Card className="bg-neutral-800 shadow-md hover:shadow-lg transition duration-200 transform hover:-translate-y-1 w-full h-full min-h-44 flex flex-col items-center justify-center">
         <CardHeader className="items-center text-center">
-          <Skeleton className="h-8 w-8 rounded-full mb-2" />
-          <Skeleton className="h-6 w-3/4" />
+          <Skeleton className="h-[1em] w-8 rounded-full mb-2" />
+          <Skeleton className="h-[1em] w-3/4" />
         </CardHeader>
         <CardContent className="text-center">
-          <Skeleton className="h-4 w-1/2 mx-auto" />
+          <Skeleton className="h-[1em] w-1/2 mx-auto" />
         </CardContent>
       </Card>
     );


### PR DESCRIPTION
## Summary
- remove width caps on section containers
- modernize Alert to flex layout
- make buttons, inputs, and textareas fluid
- tune chart and skeleton dimensions
- add responsive toast viewport and loader
- simplify sidebar widths

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_b_68408742d17c83239648b7670c5a9a2c