### PR TITLE
Update dark theme colors

### DIFF
--- a/src/components/sections/tools-metrics-section.tsx
+++ b/src/components/sections/tools-metrics-section.tsx
@@ -42,7 +42,7 @@ const tools = [
 
 export default function ToolsMetricsSection() {
   return (
-    <section id="tools" className="py-16 md:py-24 bg-neutral-900">
+    <section id="tools" className="py-16 md:py-24 bg-neutral-800">
       <div className="w-full mx-auto px-6 2xl:max-w-none">
         <h2 className="font-display text-3xl font-bold text-center text-neutral-100 mb-4">
           Ferramentas e Métricas

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -3,5 +3,10 @@
 @tailwind components;
 @tailwind utilities;
 
+:root {
+  --neutral-900: 0 0% 0%;    /* #000000 - preto puro para fundo principal */
+  --neutral-800: 240 2% 12%; /* #1E1E20 - cinza escuro para seções alternadas */
+}
+
 /* Remove focus rings unless keyboard nav */
 *:focus-visible { @apply outline-none ring-2 ring-accent; }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -14,6 +14,10 @@ export default {
         bg: { DEFAULT: "#0d0d0d", faint: "#111" },
         fg: { DEFAULT: "#e5e7eb", muted: "#a1a1aa" },
         accent: { DEFAULT: "#38bdf8", hover: "#0ea5e9" },
+        neutral: {
+          800: "#1E1E20",
+          900: "#000000",
+        },
       },
     },
   },


### PR DESCRIPTION
## Summary
- adjust CSS variables for black and dark gray
- override Tailwind neutral colors to black and gray
- alternate tools section background color

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: cannot find module 'next')*

------
https://chatgpt.com/codex/tasks/task_b_68445ae25f6483238ee717c5b9a37eac