### PR TITLE
Redesign tools metrics cards

### DIFF
--- a/src/components/sections/tools-metrics-section.tsx
+++ b/src/components/sections/tools-metrics-section.tsx
@@ -2,41 +2,47 @@ import ToolCard from '@/components/ui/tool-card';
 import { CreditCard, TrendingUp, FileText, Target, ShieldCheck, AlertTriangle } from 'lucide-react';
 
 const tools = [
-  { 
-    title: "Contas a Pagar", 
-    description: "Gerencie suas despesas e pagamentos pendentes.", 
+  {
+    title: "Contas a Pagar",
+    description: "Gerencie suas despesas e pagamentos pendentes.",
     icon: CreditCard,
-    iconColorClassName: "text-error"
+    iconColorClassName: "text-error",
+    bgGradientVia: "via-red-600",
   },
-  { 
-    title: "Receitas", 
-    description: "Acompanhe suas fontes de renda e faturamento.", 
+  {
+    title: "Receitas",
+    description: "Acompanhe suas fontes de renda e faturamento.",
     icon: TrendingUp,
-    iconColorClassName: "text-success"
+    iconColorClassName: "text-success",
+    bgGradientVia: "via-green-600",
   },
-  { 
-    title: "Relatórios Fiscais", 
-    description: "Gere relatórios detalhados e personalizados.", 
+  {
+    title: "Relatórios Fiscais",
+    description: "Gere relatórios detalhados e personalizados.",
     icon: FileText,
-    iconColorClassName: "text-secondary" // Cyan
+    iconColorClassName: "text-secondary", // Cyan
+    bgGradientVia: "via-cyan-500",
   },
-  { 
-    title: "Orçamento Anual", 
-    description: "Planeje e monitore seu orçamento para o ano.", 
+  {
+    title: "Orçamento Anual",
+    description: "Planeje e monitore seu orçamento para o ano.",
     icon: Target,
-    iconColorClassName: "text-primary-300"
+    iconColorClassName: "text-primary-300",
+    bgGradientVia: "via-violet-400",
   },
-  { 
-    title: "Compliance Fiscal", 
-    description: "Verifique a conformidade com as normas fiscais.", 
+  {
+    title: "Compliance Fiscal",
+    description: "Verifique a conformidade com as normas fiscais.",
     icon: ShieldCheck,
-    iconColorClassName: "text-warning"
+    iconColorClassName: "text-warning",
+    bgGradientVia: "via-yellow-500",
   },
-  { 
-    title: "Alertas e Notificações", 
-    description: "Receba alertas sobre prazos e pendências importantes.", 
+  {
+    title: "Alertas e Notificações",
+    description: "Receba alertas sobre prazos e pendências importantes.",
     icon: AlertTriangle,
-    iconColorClassName: "text-primary"
+    iconColorClassName: "text-primary",
+    bgGradientVia: "via-violet-600",
   },
 ];
 
@@ -50,14 +56,15 @@ export default function ToolsMetricsSection() {
         <p className="text-center text-neutral-400 mb-12 max-w-xl mx-auto">
           Acesse rapidamente as funcionalidades essenciais para a gestão fiscal eficiente e visualize seus principais indicadores.
         </p>
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-2 gap-6">
           {tools.map((tool, index) => (
-            <ToolCard 
-              key={index} 
-              title={tool.title} 
-              description={tool.description} 
+            <ToolCard
+              key={index}
+              title={tool.title}
+              description={tool.description}
               icon={tool.icon}
               iconColorClassName={tool.iconColorClassName}
+              bgGradientVia={tool.bgGradientVia}
             />
           ))}
            {/* Example of a loading card */}

--- a/src/components/ui/tool-card.tsx
+++ b/src/components/ui/tool-card.tsx
@@ -9,9 +9,10 @@ interface ToolCardProps {
   isLoading?: boolean;
   className?: string;
   iconColorClassName?: string;
+  bgGradientVia?: string;
 }
 
-export default function ToolCard({ title, description, icon: IconComponent, isLoading, className, iconColorClassName = "text-primary" }: ToolCardProps) {
+export default function ToolCard({ title, description, icon: IconComponent, isLoading, className, iconColorClassName = "text-primary", bgGradientVia = "via-neutral-700" }: ToolCardProps) {
   if (isLoading) {
     return (
       <Card className="bg-neutral-800 shadow-md hover:shadow-lg transition duration-200 transform hover:-translate-y-1 w-full h-full min-h-44 flex flex-col items-center justify-center">
@@ -27,18 +28,24 @@ export default function ToolCard({ title, description, icon: IconComponent, isLo
   }
 
   return (
-    <Card className={`bg-neutral-800 shadow-md hover:shadow-lg transition duration-200 transform hover:-translate-y-1 w-full h-full flex flex-col ${className}`}>
-      <CardHeader className="items-center text-center pt-6 pb-2">
-        {IconComponent && (
-          <div className={`mb-3 ${iconColorClassName}`}>
-            <IconComponent className="w-10 h-10" />
-          </div>
-        )}
+    <Card
+      className={
+        `relative overflow-hidden bg-gradient-to-b from-black ${bgGradientVia} to-black ` +
+        `shadow-md hover:shadow-lg transition-transform duration-200 hover:-translate-y-1 w-full h-full flex flex-col ${className}`
+      }
+    >
+      {IconComponent && (
+        <IconComponent
+          className="absolute inset-0 m-auto w-5/6 h-5/6 text-white opacity-5 -z-10"
+          style={{ strokeDasharray: "2 2", strokeLinecap: "round", strokeWidth: 1.5, fill: "none" }}
+        />
+      )}
+      <CardHeader className="relative z-10 flex flex-col items-center text-center pt-6 pb-4">
         <CardTitle className="text-neutral-100 text-xl font-semibold font-display">
           {title}
         </CardTitle>
       </CardHeader>
-      <CardContent className="text-center pb-6 flex-grow">
+      <CardContent className="relative z-10 text-center pb-6 flex-grow">
         {description && (
           <CardDescription className="text-neutral-300 text-sm">
             {description}


### PR DESCRIPTION
## Summary
- make tools metrics grid 2 columns on large screens
- add gradient color info for each tool card
- overhaul ToolCard background with gradient and watermark icon

## Testing
- `npm run lint` *(fails: prompts for config)*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_b_6845133e2e74832398e92ece0275bd2b